### PR TITLE
feat(plugins): add Wise plugin with multi-currency account grouping

### DIFF
--- a/packages/chrome/src/background.ts
+++ b/packages/chrome/src/background.ts
@@ -22,7 +22,7 @@ chrome.runtime.onMessage.addListener(async (message, sender, _sendResponse) => {
     }
 
     if (result.exportGroup) {
-      chrome.storage[CHROME_STORAGE_STRATEGY].remove("exportGroup");
+      await chrome.storage[CHROME_STORAGE_STRATEGY].remove("exportGroup");
     }
     return;
   }

--- a/packages/chrome/src/background.ts
+++ b/packages/chrome/src/background.ts
@@ -3,23 +3,26 @@ import { type AppStorage } from "@openbanker/core/types";
 
 const CHROME_STORAGE_STRATEGY = "local";
 
-// Event: Handle CSV export request from web page
 chrome.runtime.onMessage.addListener(async (message, sender, _sendResponse) => {
   if (message.name === "openbanker-transactions-csv-request") {
+    const result = await chrome.storage[CHROME_STORAGE_STRATEGY].get(["transactionStore", "exportGroup"]) as Partial<AppStorage>;
 
-    const keysToGet: Array<keyof AppStorage> = ["transactionStore"];
-    const result = await chrome.storage[CHROME_STORAGE_STRATEGY].get(keysToGet) as Partial<AppStorage>;
+    // exportGroup is set by SyncAccountsButton for per-group export; fall back to all transactions
+    const transactions = result.exportGroup
+      ?? result.transactionStore?.groups?.flatMap(g => g.transactions)
+      ?? [];
 
-    if (result.transactionStore) {
-      const csvContent = toCSV(result.transactionStore.transactions);
+    const csvContent = toCSV(transactions);
 
-      // Send response back to the requesting tab
-      if (sender.tab?.id) {
-        chrome.tabs.sendMessage(sender.tab.id, {
-          name: "openbanker-transactions-csv-response",
-          transactions: csvContent,
-        });
-      }
+    if (sender.tab?.id) {
+      chrome.tabs.sendMessage(sender.tab.id, {
+        name: "openbanker-transactions-csv-response",
+        transactions: csvContent,
+      });
+    }
+
+    if (result.exportGroup) {
+      chrome.storage[CHROME_STORAGE_STRATEGY].remove("exportGroup");
     }
     return;
   }

--- a/packages/core/src/types/openbanker.ts
+++ b/packages/core/src/types/openbanker.ts
@@ -1,6 +1,11 @@
+export type TransactionGroup = {
+  account: string;
+  transactions: Transaction[];
+}
+
 export type TransactionList = {
-  transactions: Transaction[],
-  pluginName: string
+  groups: TransactionGroup[];
+  pluginName: string;
 }
 
 export type ActualBudgetAccount = {
@@ -9,12 +14,13 @@ export type ActualBudgetAccount = {
 }
 
 export function emptyTransactionStore(): TransactionList {
-  return { transactions: [], pluginName: "" }
+  return { groups: [], pluginName: "" }
 }
 
 export type AppStorage = {
-  transactionStore: TransactionList; // transactions marked for import into ActualBudget
-  actualBudgetAccounts: ActualBudgetAccount[]; // ActualBudget accounts fetched from the app
+  transactionStore: TransactionList;
+  actualBudgetAccounts: ActualBudgetAccount[];
+  exportGroup: Transaction[];
 }
 
 export type Transaction = {

--- a/packages/core/src/types/openbanker.ts
+++ b/packages/core/src/types/openbanker.ts
@@ -20,7 +20,7 @@ export function emptyTransactionStore(): TransactionList {
 export type AppStorage = {
   transactionStore: TransactionList;
   actualBudgetAccounts: ActualBudgetAccount[];
-  exportGroup: Transaction[];
+  exportGroup?: Transaction[];
 }
 
 export type Transaction = {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,14 +5,14 @@ import config from "@/config";
 
 import TransactionsTable from "@/components/TransactionsTable";
 import ActionButtons from "@/components/ActionButtons";
+import SyncAccountsButton from "@/components/ActionButtons/SyncAccountsButton";
 import EmptyState from "@/components/EmptyState";
-import { emptyTransactionStore } from "@openbanker/core/types";
+import { emptyTransactionStore, type TransactionGroup, type Transaction } from "@openbanker/core/types";
 import { getChromeContext } from "@/lib/utils";
 import useChromeStorage from "@/hooks/useChromeStorage";
 
 export default function App() {
   const [transactionStore, setTransactionStore] = useChromeStorage("transactionStore", emptyTransactionStore())
-
 
   useEffect(() => {
     if (getChromeContext() !== 'extension') return;
@@ -33,7 +33,14 @@ export default function App() {
         });
 
         if (res && res[0] && res[0].result) {
-          setTransactionStore({ pluginName: plugin.name, transactions: res[0].result });
+          const raw = res[0].result as TransactionGroup[] | Transaction[];
+          let groups: TransactionGroup[];
+          if (Array.isArray(raw) && raw.length > 0 && 'account' in raw[0]) {
+            groups = raw as TransactionGroup[];
+          } else {
+            groups = [{ account: plugin.name, transactions: raw as Transaction[] }];
+          }
+          setTransactionStore({ pluginName: plugin.name, groups });
         }
 
       }
@@ -41,6 +48,9 @@ export default function App() {
     detectTransactions();
 
   }, []);
+
+  const hasData = transactionStore.pluginName !== "";
+  const multiGroup = transactionStore.groups.length > 1;
 
   return (
     <div className="m-5 flex flex-col space-y-5 min-w-[600px]">
@@ -56,16 +66,31 @@ export default function App() {
       </div>
 
       {
-        transactionStore.pluginName !== "" && (
-          < div className="font-bold">
+        hasData && (
+          <div className="font-bold">
             Plugin: {transactionStore.pluginName}
           </div>
         )
-
       }
 
-      {transactionStore.pluginName === "" ? <EmptyState /> : <TransactionsTable transactions={transactionStore.transactions} />}
-
+      {!hasData ? <EmptyState /> : (
+        transactionStore.groups.map(group => (
+          <div key={group.account} className="flex flex-col space-y-2">
+            <div className="flex items-center justify-between">
+              {multiGroup && (
+                <span className="font-semibold">
+                  {group.account}
+                  <span className="ml-2 text-sm font-normal text-gray-500">
+                    ({group.transactions.length})
+                  </span>
+                </span>
+              )}
+              <SyncAccountsButton group={group} />
+            </div>
+            <TransactionsTable transactions={group.transactions} />
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/components/ActionButtons/ActionButtons.tsx
+++ b/packages/frontend/src/components/ActionButtons/ActionButtons.tsx
@@ -27,22 +27,6 @@ export default function ActionButtons() {
         {/*   </Button> */}
         {/* </ButtonGroup> */}
         <ButtonGroup>
-          {/* <SyncAccountsButton /> */}
-          {/* <Button */}
-          {/*   size="sm" */}
-          {/*   className="group" */}
-          {/*   asChild> */}
-          {/*   <a */}
-          {/*     href="https://actual.amperleft.com/" */}
-          {/*     target="_blank" */}
-          {/*     rel="noopener noreferrer" */}
-          {/*     className="bg-red-200 hover:bg-red-300" */}
-          {/*   > */}
-          {/*     <FaExternalLinkAlt className="text-black transition-transform duration-300 ease-in-out group-hover:rotate-90 group-hover:scale-150" /> */}
-          {/*   </a> */}
-          {/* </Button> */}
-        </ButtonGroup>
-        <ButtonGroup>
           <DownloadCsvButton />
         </ButtonGroup>
       </ButtonGroup>

--- a/packages/frontend/src/components/ActionButtons/ActionButtons.tsx
+++ b/packages/frontend/src/components/ActionButtons/ActionButtons.tsx
@@ -5,7 +5,7 @@ import { ButtonGroup } from "@/components/ui/button-group";
 // import { Button } from "@/components/ui/button";
 
 import DownloadCsvButton from "@/components/ActionButtons/DownloadCsvButton";
-import SyncAccountsButton from "./SyncAccountsButton";
+// import SyncAccountsButton from "./SyncAccountsButton"; // moved to per-group in App.tsx
 // import CategorizeButton from "@/components/ActionButtons/Categorization/CategorizeButton";
 // import CategoryConfigDialog from "@/components/ActionButtons/Categorization/CategoryConfigDialog";
 
@@ -27,7 +27,7 @@ export default function ActionButtons() {
         {/*   </Button> */}
         {/* </ButtonGroup> */}
         <ButtonGroup>
-          <SyncAccountsButton />
+          {/* <SyncAccountsButton /> */}
           {/* <Button */}
           {/*   size="sm" */}
           {/*   className="group" */}

--- a/packages/frontend/src/components/ActionButtons/DownloadCsvButton.tsx
+++ b/packages/frontend/src/components/ActionButtons/DownloadCsvButton.tsx
@@ -11,7 +11,8 @@ export default function DownloadCSVButton() {
   function exportCSV() {
     const pluginNameSnakeCase = currTransactions.pluginName.replace(/\s+/g, "_").toLowerCase();
 
-    const csvContent = toCSV(currTransactions.transactions);
+    const allTransactions = currTransactions.groups.flatMap(g => g.transactions);
+    const csvContent = toCSV(allTransactions);
 
     // Create a blob and trigger download
     // A Blob is a high-level representation of immutable raw data (data object)

--- a/packages/frontend/src/components/ActionButtons/SyncAccountsButton.tsx
+++ b/packages/frontend/src/components/ActionButtons/SyncAccountsButton.tsx
@@ -14,9 +14,14 @@ import { CiBank } from "react-icons/ci";
 import { HiChevronDown } from "react-icons/hi2";
 
 import useChromeStorage from "@/hooks/useChromeStorage";
-import type { ActualBudgetAccount } from "@openbanker/core/types";
+import type { ActualBudgetAccount, TransactionGroup } from "@openbanker/core/types";
+import { CHROME_STORAGE_STRATEGY } from "@/hooks/useChromeStorage";
 
-export default function SyncAccountsButton() {
+type Props = {
+  group: TransactionGroup;
+}
+
+export default function SyncAccountsButton({ group }: Props) {
   const [actualBudgetAccounts] = useChromeStorage("actualBudgetAccounts", []);
   const [currActualBudgetAccount, setCurrActualBudgetAccount] = useState<ActualBudgetAccount | null>(null);
 
@@ -26,7 +31,11 @@ export default function SyncAccountsButton() {
 
   function handleExportToAccount() {
     if (currActualBudgetAccount === null) return;
-    window.open(`https://demo.openbanker.org/accounts/${currActualBudgetAccount.id}?openBankerSync=true`, "_blank");
+    const url = `https://demo.openbanker.org/accounts/${currActualBudgetAccount.id}?openBankerSync=true`;
+    // Write this group's transactions first, then open the tab once storage is confirmed written
+    chrome.storage[CHROME_STORAGE_STRATEGY].set({ exportGroup: group.transactions }, () => {
+      window.open(url, "_blank");
+    });
   }
 
   const isCurrAccountNull = currActualBudgetAccount === null;

--- a/packages/frontend/src/components/ActionButtons/SyncAccountsButton.tsx
+++ b/packages/frontend/src/components/ActionButtons/SyncAccountsButton.tsx
@@ -34,6 +34,10 @@ export default function SyncAccountsButton({ group }: Props) {
     const url = `https://demo.openbanker.org/accounts/${currActualBudgetAccount.id}?openBankerSync=true`;
     // Write this group's transactions first, then open the tab once storage is confirmed written
     chrome.storage[CHROME_STORAGE_STRATEGY].set({ exportGroup: group.transactions }, () => {
+      if (chrome.runtime.lastError) {
+        console.error("Failed to write exportGroup:", chrome.runtime.lastError);
+        return;
+      }
       window.open(url, "_blank");
     });
   }

--- a/packages/frontend/src/components/EmptyState/EmptyState.tsx
+++ b/packages/frontend/src/components/EmptyState/EmptyState.tsx
@@ -10,6 +10,7 @@ export default function EmptyState() {
       <li>Scotiabank Credit</li>
       <li>Wealthsimple</li>
       <li>Rogersbank</li>
+      <li>Wise</li>
     </ul>
 
   </div>

--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -41,7 +41,7 @@ const config: Config = {
     },
     {
       name: "NGPF",
-      urlPattern: /ngpf\.org\/bank-sim\/account/g,
+      urlPattern: /ngpf\.org\/bank-sim\/account/,
       scrapeFunc: NGPF
     },
     {

--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -1,11 +1,11 @@
-import type { Transaction } from "@openbanker/core/types";
+import type { Transaction, TransactionGroup } from "@openbanker/core/types";
 
 import { ScotiabankCredit, ScotiabankChequing, RBC, RogersBank, Wealthsimple, NGPF, Wise } from "@openbanker/plugins";
 
 export type PluginConfig = {
   name: string;
   urlPattern: RegExp;
-  scrapeFunc: () => Transaction[];
+  scrapeFunc: () => TransactionGroup[] | Transaction[];
 }
 
 export type Config = {

--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from "@openbanker/core/types";
 
-import { ScotiabankCredit, ScotiabankChequing, RBC, RogersBank, Wealthsimple, NGPF } from "@openbanker/plugins";
+import { ScotiabankCredit, ScotiabankChequing, RBC, RogersBank, Wealthsimple, NGPF, Wise } from "@openbanker/plugins";
 
 export type PluginConfig = {
   name: string;
@@ -43,6 +43,11 @@ const config: Config = {
       name: "NGPF",
       urlPattern: /ngpf\.org\/bank-sim\/account/g,
       scrapeFunc: NGPF
+    },
+    {
+      name: "Wise",
+      urlPattern: /wise\.com\/(home|all-transactions)/,
+      scrapeFunc: Wise
     }
   ]
 }

--- a/packages/plugins/src/Wise.ts
+++ b/packages/plugins/src/Wise.ts
@@ -8,7 +8,7 @@ export default function scrape(): TransactionGroup[] {
       jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12
     };
 
-    // "16 May 2026" or "11 March 2025" — year always present on /all-transactions
+    // "16 May 2026" or "11 March 2025" — full date with year
     const fullMatch = str.match(/^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/);
     if (fullMatch) {
       const day = fullMatch[1].padStart(2, '0');
@@ -17,13 +17,34 @@ export default function scrape(): TransactionGroup[] {
       if (monthIdx) return `${year}-${String(monthIdx).padStart(2, '0')}-${day}`;
     }
 
-    // Relative dates from /home page
     const now = new Date();
     const lower = str.toLowerCase();
     if (lower === 'today') return now.toISOString().slice(0, 10);
     if (lower === 'yesterday') {
       const d = new Date(now);
       d.setDate(d.getDate() - 1);
+      return d.toISOString().slice(0, 10);
+    }
+
+    // "Card checked · Tue, 12 May" — strip status prefix and recurse
+    if (str.includes(' · ')) {
+      return parseDate(str.split(' · ').pop()!);
+    }
+
+    // "Tue, 12 May" — strip day-of-week prefix and recurse
+    const dayPrefixMatch = str.match(/^[A-Za-z]{2,3},?\s+(.+)$/);
+    if (dayPrefixMatch && /\d/.test(dayPrefixMatch[1])) {
+      return parseDate(dayPrefixMatch[1]);
+    }
+
+    // "Friday", "Monday", etc. — most recent occurrence of that weekday
+    const dayNames = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+    const dayIdx = dayNames.indexOf(lower);
+    if (dayIdx !== -1) {
+      let daysBack = (now.getDay() - dayIdx + 7) % 7;
+      if (daysBack === 0) daysBack = 7; // "today" shows as "Today", so this must be last week
+      const d = new Date(now);
+      d.setDate(now.getDate() - daysBack);
       return d.toISOString().slice(0, 10);
     }
 
@@ -61,12 +82,6 @@ export default function scrape(): TransactionGroup[] {
     };
   }
 
-  const links = Array.from(
-    document.querySelectorAll<HTMLAnchorElement>('a[data-testid="activity-summary"]')
-  );
-
-  if (!links.length) return [];
-
   const groups: Record<string, Transaction[]> = {};
 
   function addToGroup(currency: string, tx: Transaction) {
@@ -74,86 +89,80 @@ export default function scrape(): TransactionGroup[] {
     groups[currency].push(tx);
   }
 
-  for (const link of links) {
-    const statusEl = link.querySelector<HTMLElement>('[id$="-status"]');
-    if (statusEl?.textContent?.trim().toLowerCase() === 'cancelled') continue;
+  // --- /all-transactions page ---
+  const allTxLinks = Array.from(
+    document.querySelectorAll<HTMLAnchorElement>('a[data-testid="activity-summary"]')
+  );
 
-    const titleEl = link.querySelector<HTMLElement>('[id$="-title"]');
-    const amountEl = link.querySelector<HTMLElement>('[id$="-amount"]');
-    const dateEl = link.querySelector<HTMLElement>('[id$="-date"]');
+  if (allTxLinks.length) {
+    for (const link of allTxLinks) {
+      const statusEl = link.querySelector<HTMLElement>('[id$="-status"]');
+      if (statusEl?.textContent?.trim().toLowerCase() === 'cancelled') continue;
 
-    if (!titleEl || !amountEl) continue;
+      const titleEl = link.querySelector<HTMLElement>('[id$="-title"]');
+      const amountEl = link.querySelector<HTMLElement>('[id$="-amount"]');
+      const dateEl = link.querySelector<HTMLElement>('[id$="-date"]');
 
-    const parsed = parseAmount(amountEl);
-    if (!parsed) continue;
+      if (!titleEl || !amountEl) continue;
 
-    const hrefMatch = link.href.match(/by-resource\/([^/]+)\/(\d+)/);
-    const external_id = hrefMatch ? `${hrefMatch[1]}-${hrefMatch[2]}` : '';
+      const parsed = parseAmount(amountEl);
+      if (!parsed) continue;
 
-    const title = titleEl.textContent?.trim() ?? '';
-    const isConversionIn = /^To\s+[A-Z]{3}$/.test(title);
-    const date = parseDate(dateEl?.textContent?.trim() ?? '');
-    const amountInfoEl = link.querySelector<HTMLElement>('[class*="amountInfo"]');
+      const hrefMatch = link.href.match(/by-resource\/([^/]+)\/(\d+)/);
+      const external_id = hrefMatch ? `${hrefMatch[1]}-${hrefMatch[2]}` : '';
+      const title = titleEl.textContent?.trim() ?? '';
+      const isConversionIn = /^To\s+[A-Z]{3}$/.test(title);
+      const date = parseDate(dateEl?.textContent?.trim() ?? '');
+      const amountInfoEl = link.querySelector<HTMLElement>('[class*="amountInfo"]');
 
-    if (isConversionIn) {
-      // "To CAD": deposit the received currency, withdraw the sent currency
-      addToGroup(parsed.currency, {
-        date,
-        description: title,
-        amount: parsed.amount,
-        type: 'deposit',
-        category_name: '',
-        external_id,
-        notes: parsed.currency,
-      });
-
-      if (amountInfoEl) {
-        const sourceText = amountInfoEl.textContent?.trim() ?? '';
-        const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
-        if (sourceMatch) {
-          addToGroup(sourceMatch[2], {
-            date,
-            description: title,
-            amount: parseFloat(sourceMatch[1].replace(/,/g, '')),
-            type: 'withdrawal',
-            category_name: '',
-            external_id: external_id ? `${external_id}-debit` : '',
-            notes: sourceMatch[2],
-          });
+      if (isConversionIn) {
+        addToGroup(parsed.currency, { date, description: title, amount: parsed.amount, type: 'deposit', category_name: '', external_id, notes: parsed.currency });
+        if (amountInfoEl) {
+          const sourceMatch = amountInfoEl.textContent?.trim().match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
+          if (sourceMatch) {
+            addToGroup(sourceMatch[2], { date, description: title, amount: parseFloat(sourceMatch[1].replace(/,/g, '')), type: 'withdrawal', category_name: '', external_id: external_id ? `${external_id}-debit` : '', notes: sourceMatch[2] });
+          }
         }
-      }
-    } else if (!parsed.isDeposit && amountInfoEl) {
-      // Auto-converted purchase (e.g. paid 18 CNY but deducted from MYR):
-      // the main amount is the merchant's currency — record only the actual wallet deduction
-      const sourceText = amountInfoEl.textContent?.trim() ?? '';
-      const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
-      if (sourceMatch) {
-        addToGroup(sourceMatch[2], {
-          date,
-          description: title,
-          amount: parseFloat(sourceMatch[1].replace(/,/g, '')),
-          type: 'withdrawal',
-          category_name: '',
-          external_id,
-          notes: `${parsed.amount} ${parsed.currency}`,
-        });
+      } else if (!parsed.isDeposit && amountInfoEl) {
+        const sourceMatch = amountInfoEl.textContent?.trim().match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
+        if (sourceMatch) {
+          addToGroup(sourceMatch[2], { date, description: title, amount: parseFloat(sourceMatch[1].replace(/,/g, '')), type: 'withdrawal', category_name: '', external_id, notes: `${parsed.amount} ${parsed.currency}` });
+        } else {
+          addToGroup(parsed.currency, { date, description: title, amount: parsed.amount, type: 'withdrawal', category_name: '', external_id, notes: parsed.currency });
+        }
       } else {
-        // Fallback: couldn't parse amountInfo, record the main amount as-is
-        addToGroup(parsed.currency, {
-          date,
-          description: title,
-          amount: parsed.amount,
-          type: 'withdrawal',
-          category_name: '',
-          external_id,
-          notes: parsed.currency,
-        });
+        addToGroup(parsed.currency, { date, description: title, amount: parsed.amount, type: parsed.isDeposit ? 'deposit' : 'withdrawal', category_name: '', external_id, notes: parsed.currency });
       }
-    } else {
-      // Regular transaction (single currency purchase or deposit)
+    }
+  } else {
+    // --- /home page fallback ---
+    const homeLinks = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('a[href*="urn%3Awise%3Aactivities%3A"]')
+    );
+
+    for (const link of homeLinks) {
+      const titleEl = link.querySelector<HTMLElement>('[class*="activitySummaryTitle"]');
+      const dateEl = link.querySelector<HTMLElement>('[class*="activitySummaryDescription"]');
+      const amountEl = link.querySelector<HTMLElement>('[class*="summaryAmount"]');
+
+      if (!titleEl || !amountEl) continue;
+
+      const parsed = parseAmount(amountEl);
+      if (!parsed) continue;
+
+      let external_id = '';
+      const urnMatch = link.href.match(/urn%3Awise%3Aactivities%3A([^&]+)/);
+      if (urnMatch) {
+        try {
+          const decoded = atob(decodeURIComponent(urnMatch[1]));
+          const parts = decoded.split('::');
+          if (parts.length >= 4) external_id = `${parts[2]}-${parts[3]}`;
+        } catch (_) {}
+      }
+
       addToGroup(parsed.currency, {
-        date,
-        description: title,
+        date: parseDate(dateEl?.textContent?.trim() ?? ''),
+        description: titleEl.textContent?.trim() ?? '',
         amount: parsed.amount,
         type: parsed.isDeposit ? 'deposit' : 'withdrawal',
         category_name: '',

--- a/packages/plugins/src/Wise.ts
+++ b/packages/plugins/src/Wise.ts
@@ -69,7 +69,7 @@ export default function scrape(): TransactionGroup[] {
     const positiveSpan = amountEl.querySelector<HTMLElement>('[class*="positive"]');
     const rawText = (positiveSpan ?? amountEl).textContent?.trim() ?? '';
     const isDeposit = !!positiveSpan || rawText.startsWith('+');
-    const cleaned = rawText.replace(/^\+\s*/, '').trim();
+    const cleaned = rawText.replace(/^[+\-]\s*/, '').trim();
     const match = cleaned.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
     if (!match) {
       console.warn("Wise: could not parse amount:", rawText);
@@ -157,7 +157,7 @@ export default function scrape(): TransactionGroup[] {
           const decoded = atob(decodeURIComponent(urnMatch[1]));
           const parts = decoded.split('::');
           if (parts.length >= 4) external_id = `${parts[2]}-${parts[3]}`;
-        } catch (_) {}
+        } catch (_) { }
       }
 
       addToGroup(parsed.currency, {

--- a/packages/plugins/src/Wise.ts
+++ b/packages/plugins/src/Wise.ts
@@ -1,0 +1,123 @@
+import type { Transaction } from "@openbanker/core/types";
+
+export default function scrape(): Transaction[] {
+  function parseDate(raw: string): string {
+    const str = raw.trim();
+    const months: Record<string, number> = {
+      jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+      jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12
+    };
+
+    // "16 May 2026" or "11 March 2025" — year always present on /all-transactions
+    const fullMatch = str.match(/^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/);
+    if (fullMatch) {
+      const day = fullMatch[1].padStart(2, '0');
+      const monthIdx = months[fullMatch[2].toLowerCase().slice(0, 3)];
+      const year = fullMatch[3];
+      if (monthIdx) return `${year}-${String(monthIdx).padStart(2, '0')}-${day}`;
+    }
+
+    // Relative dates from /home page
+    const now = new Date();
+    const lower = str.toLowerCase();
+    if (lower === 'today') return now.toISOString().slice(0, 10);
+    if (lower === 'yesterday') {
+      const d = new Date(now);
+      d.setDate(d.getDate() - 1);
+      return d.toISOString().slice(0, 10);
+    }
+
+    // "5 Jun" or "5 June" without year (/home page)
+    const shortMatch = str.match(/^(\d{1,2})\s+([A-Za-z]+)$/);
+    if (shortMatch) {
+      const day = parseInt(shortMatch[1]);
+      const monthIdx = months[shortMatch[2].toLowerCase().slice(0, 3)];
+      if (monthIdx) {
+        const year = now.getFullYear();
+        const candidate = new Date(year, monthIdx - 1, day);
+        if (candidate > now) candidate.setFullYear(year - 1);
+        return `${candidate.getFullYear()}-${String(monthIdx).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+      }
+    }
+
+    console.warn("Wise: could not parse date:", str);
+    return "";
+  }
+
+  function parseAmount(amountEl: HTMLElement): { amount: number; currency: string; isDeposit: boolean } | null {
+    const positiveSpan = amountEl.querySelector<HTMLElement>('[class*="positive"]');
+    const rawText = (positiveSpan ?? amountEl).textContent?.trim() ?? '';
+    const isDeposit = !!positiveSpan || rawText.startsWith('+');
+    const cleaned = rawText.replace(/^\+\s*/, '').trim();
+    const match = cleaned.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
+    if (!match) {
+      console.warn("Wise: could not parse amount:", rawText);
+      return null;
+    }
+    return {
+      amount: parseFloat(match[1].replace(/,/g, '')),
+      currency: match[2],
+      isDeposit,
+    };
+  }
+
+  const links = Array.from(
+    document.querySelectorAll<HTMLAnchorElement>('a[data-testid="activity-summary"]')
+  );
+
+  if (!links.length) return [];
+
+  const transactions: Transaction[] = [];
+  for (const link of links) {
+    const statusEl = link.querySelector<HTMLElement>('[id$="-status"]');
+    if (statusEl?.textContent?.trim().toLowerCase() === 'cancelled') continue;
+
+    const titleEl = link.querySelector<HTMLElement>('[id$="-title"]');
+    const amountEl = link.querySelector<HTMLElement>('[id$="-amount"]');
+    const dateEl = link.querySelector<HTMLElement>('[id$="-date"]');
+
+    if (!titleEl || !amountEl) continue;
+
+    const parsed = parseAmount(amountEl);
+    if (!parsed) continue;
+
+    const hrefMatch = link.href.match(/by-resource\/([^/]+)\/(\d+)/);
+    const external_id = hrefMatch ? `${hrefMatch[1]}-${hrefMatch[2]}` : '';
+
+    const title = titleEl.textContent?.trim() ?? '';
+    const isConversionIn = /^To\s+[A-Z]{3}$/.test(title);
+    const date = parseDate(dateEl?.textContent?.trim() ?? '');
+
+    transactions.push({
+      date,
+      description: title,
+      amount: parsed.amount,
+      type: (parsed.isDeposit || isConversionIn) ? 'deposit' : 'withdrawal',
+      category_name: '',
+      external_id,
+      notes: parsed.currency,
+    });
+
+    // For currency conversions, also record the source currency as a withdrawal
+    if (isConversionIn) {
+      const amountInfoEl = link.querySelector<HTMLElement>('[class*="amountInfo"]');
+      if (amountInfoEl) {
+        const sourceText = amountInfoEl.textContent?.trim() ?? '';
+        const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
+        if (sourceMatch) {
+          transactions.push({
+            date,
+            description: title,
+            amount: parseFloat(sourceMatch[1].replace(/,/g, '')),
+            type: 'withdrawal',
+            category_name: '',
+            external_id: external_id ? `${external_id}-debit` : '',
+            notes: sourceMatch[2],
+          });
+        }
+      }
+    }
+  }
+
+  return transactions;
+}

--- a/packages/plugins/src/Wise.ts
+++ b/packages/plugins/src/Wise.ts
@@ -93,20 +93,20 @@ export default function scrape(): TransactionGroup[] {
     const title = titleEl.textContent?.trim() ?? '';
     const isConversionIn = /^To\s+[A-Z]{3}$/.test(title);
     const date = parseDate(dateEl?.textContent?.trim() ?? '');
+    const amountInfoEl = link.querySelector<HTMLElement>('[class*="amountInfo"]');
 
-    addToGroup(parsed.currency, {
-      date,
-      description: title,
-      amount: parsed.amount,
-      type: (parsed.isDeposit || isConversionIn) ? 'deposit' : 'withdrawal',
-      category_name: '',
-      external_id,
-      notes: parsed.currency,
-    });
-
-    // For currency conversions, also record the source currency as a withdrawal
     if (isConversionIn) {
-      const amountInfoEl = link.querySelector<HTMLElement>('[class*="amountInfo"]');
+      // "To CAD": deposit the received currency, withdraw the sent currency
+      addToGroup(parsed.currency, {
+        date,
+        description: title,
+        amount: parsed.amount,
+        type: 'deposit',
+        category_name: '',
+        external_id,
+        notes: parsed.currency,
+      });
+
       if (amountInfoEl) {
         const sourceText = amountInfoEl.textContent?.trim() ?? '';
         const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
@@ -122,6 +122,44 @@ export default function scrape(): TransactionGroup[] {
           });
         }
       }
+    } else if (!parsed.isDeposit && amountInfoEl) {
+      // Auto-converted purchase (e.g. paid 18 CNY but deducted from MYR):
+      // the main amount is the merchant's currency — record only the actual wallet deduction
+      const sourceText = amountInfoEl.textContent?.trim() ?? '';
+      const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
+      if (sourceMatch) {
+        addToGroup(sourceMatch[2], {
+          date,
+          description: title,
+          amount: parseFloat(sourceMatch[1].replace(/,/g, '')),
+          type: 'withdrawal',
+          category_name: '',
+          external_id,
+          notes: `${parsed.amount} ${parsed.currency}`,
+        });
+      } else {
+        // Fallback: couldn't parse amountInfo, record the main amount as-is
+        addToGroup(parsed.currency, {
+          date,
+          description: title,
+          amount: parsed.amount,
+          type: 'withdrawal',
+          category_name: '',
+          external_id,
+          notes: parsed.currency,
+        });
+      }
+    } else {
+      // Regular transaction (single currency purchase or deposit)
+      addToGroup(parsed.currency, {
+        date,
+        description: title,
+        amount: parsed.amount,
+        type: parsed.isDeposit ? 'deposit' : 'withdrawal',
+        category_name: '',
+        external_id,
+        notes: parsed.currency,
+      });
     }
   }
 

--- a/packages/plugins/src/Wise.ts
+++ b/packages/plugins/src/Wise.ts
@@ -1,6 +1,6 @@
-import type { Transaction } from "@openbanker/core/types";
+import type { Transaction, TransactionGroup } from "@openbanker/core/types";
 
-export default function scrape(): Transaction[] {
+export default function scrape(): TransactionGroup[] {
   function parseDate(raw: string): string {
     const str = raw.trim();
     const months: Record<string, number> = {
@@ -67,7 +67,13 @@ export default function scrape(): Transaction[] {
 
   if (!links.length) return [];
 
-  const transactions: Transaction[] = [];
+  const groups: Record<string, Transaction[]> = {};
+
+  function addToGroup(currency: string, tx: Transaction) {
+    if (!groups[currency]) groups[currency] = [];
+    groups[currency].push(tx);
+  }
+
   for (const link of links) {
     const statusEl = link.querySelector<HTMLElement>('[id$="-status"]');
     if (statusEl?.textContent?.trim().toLowerCase() === 'cancelled') continue;
@@ -88,7 +94,7 @@ export default function scrape(): Transaction[] {
     const isConversionIn = /^To\s+[A-Z]{3}$/.test(title);
     const date = parseDate(dateEl?.textContent?.trim() ?? '');
 
-    transactions.push({
+    addToGroup(parsed.currency, {
       date,
       description: title,
       amount: parsed.amount,
@@ -105,7 +111,7 @@ export default function scrape(): Transaction[] {
         const sourceText = amountInfoEl.textContent?.trim() ?? '';
         const sourceMatch = sourceText.match(/^([\d,]+\.?\d*)\s+([A-Z]{3})$/);
         if (sourceMatch) {
-          transactions.push({
+          addToGroup(sourceMatch[2], {
             date,
             description: title,
             amount: parseFloat(sourceMatch[1].replace(/,/g, '')),
@@ -119,5 +125,8 @@ export default function scrape(): Transaction[] {
     }
   }
 
-  return transactions;
+  return Object.entries(groups).map(([currency, transactions]) => ({
+    account: `Wise ${currency}`,
+    transactions,
+  }));
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -4,5 +4,6 @@ import ScotiabankCredit from "./ScotiabankCredit";
 import Wealthsimple from "./Wealthsimple";
 import RogersBank from "./RogersBank";
 import NGPF from "./NGPF.ts"
+import Wise from "./Wise";
 
-export { RBC, ScotiabankChequing, Wealthsimple, ScotiabankCredit, RogersBank, NGPF };
+export { RBC, ScotiabankChequing, Wealthsimple, ScotiabankCredit, RogersBank, NGPF, Wise };


### PR DESCRIPTION
# Summary
- Adds a Wise plugin that scrapes transactions from both the /all-transactions and /home pages
- Introduces TransactionGroup to support plugins returning multiple named account groups, with auto-wrapping for single-group plugins
- Wise transactions are automatically split into separate groups per currency (e.g. "Wise CAD", "Wise MYR") so each can be exported independently to a different ActualBudget account
- SyncAccountsButton now accepts a group prop and stages only that group's transactions before opening ActualBudget, enabling per-account export
- Correctly handles currency conversions: "To CAD" creates a deposit in the target currency and a withdrawal in the source; auto-converted purchases (e.g. paying CNY from MYR balance) are recorded only against the wallet currency

## Test plan
  - Open Wise /all-transactions — transactions appear split by currency group
  - Open Wise /home — recent transactions are scraped correctly
  - Perform "Export to X" on a single currency group — only that group's transactions are imported into ActualBudget
  - Download CSV — all groups are flattened into one file
  - Non-Wise plugins still work (single group, no regression)
  - Conversion transactions ("To CAD") appear as deposit in CAD group and withdrawal in source currency group
  - Auto-converted purchases appear only in wallet currency group (no phantom negative balances)